### PR TITLE
fix: do not write userInfoResponse payload into header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,19 +30,35 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17.2</version>
+        <version>20.2</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
+        <gravitee-bom.version>2.6</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.35.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-common.version>1.19.0</gravitee-common.version>
+        <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-expression-language.version>1.9.3</gravitee-expression-language.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -64,6 +80,13 @@
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
             <version>${gravitee-policy-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -90,7 +113,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -98,20 +120,26 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/io/gravitee/policy/openid/userinfo/CopyAttributeToResponsePayloadPolicy.java
+++ b/src/test/java/io/gravitee/policy/openid/userinfo/CopyAttributeToResponsePayloadPolicy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.openid.userinfo;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CopyAttributeToResponsePayloadPolicy {
+
+    public static final String NO_CONTENT = "noContent";
+
+    @OnResponseContent
+    public ReadWriteStream<Buffer> onResponseContent(ExecutionContext context) {
+        return new BufferedReadWriteStream() {
+            @Override
+            public SimpleReadWriteStream<Buffer> write(Buffer content) {
+                return this;
+            }
+
+            @Override
+            public void end() {
+                String content = NO_CONTENT;
+                final Object userInfoContent = context.getAttribute(UserInfoPolicy.CONTEXT_ATTRIBUTE_OPENID_USERINFO_PAYLOAD);
+                if (userInfoContent != null) {
+                    content = userInfoContent.toString();
+                }
+                super.write(Buffer.buffer(content));
+                super.end();
+            }
+        };
+    }
+}

--- a/src/test/java/io/gravitee/policy/openid/userinfo/DummyOauth2Resource.java
+++ b/src/test/java/io/gravitee/policy/openid/userinfo/DummyOauth2Resource.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.openid.userinfo;
+
+import static io.gravitee.policy.openid.userinfo.UserInfoPolicyIntegrationTest.CAUSING_ERROR_TOKEN;
+import static io.gravitee.policy.openid.userinfo.UserInfoPolicyIntegrationTest.NO_PAYLOAD_EXTRACTION_PATH;
+import static io.gravitee.policy.openid.userinfo.UserInfoPolicyIntegrationTest.PAYLOAD_EXTRACTION_PATH;
+
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.resource.api.ResourceConfiguration;
+import io.gravitee.resource.oauth2.api.OAuth2Resource;
+import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DummyOauth2Resource extends OAuth2Resource<DummyOauth2Resource.DummyOauth2ResourceConfiguration> {
+
+    public static final String EXTRACTED_PAYLOAD = "Extracted payload!";
+    public static final String EXTRACTED_FAIL_PAYLOAD = "Extracted fail payload!";
+    public static final String THROWABLE_MESSAGE = "Throwable message";
+
+    @Override
+    public void introspect(String token, Handler handler) {}
+
+    @Override
+    public void userInfo(String token, Handler<UserInfoResponse> handler) {
+        UserInfoResponse response = new UserInfoResponse(false, EXTRACTED_FAIL_PAYLOAD);
+        if (PAYLOAD_EXTRACTION_PATH.equals(token) || NO_PAYLOAD_EXTRACTION_PATH.equals(token)) {
+            response = new UserInfoResponse(true, EXTRACTED_PAYLOAD);
+        } else if (CAUSING_ERROR_TOKEN.equals(token)) {
+            response = new UserInfoResponse(new RuntimeException(THROWABLE_MESSAGE));
+        }
+
+        handler.handle(response);
+    }
+
+    public static class DummyOauth2ResourceConfiguration implements ResourceConfiguration {}
+}

--- a/src/test/java/io/gravitee/policy/openid/userinfo/UserInfoPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/openid/userinfo/UserInfoPolicyIntegrationTest.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.openid.userinfo;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.policy.openid.userinfo.configuration.UserInfoPolicyConfiguration;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpRequest;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/user-info.json")
+class UserInfoPolicyIntegrationTest extends AbstractPolicyTest<UserInfoPolicy, UserInfoPolicyConfiguration> {
+
+    public static final String PAYLOAD_EXTRACTION_PATH = "/payload-extraction";
+    public static final String NO_PAYLOAD_EXTRACTION_PATH = "/no-payload-extraction";
+
+    public static final String CAUSING_ERROR_TOKEN = "causing_error_token";
+
+    @Override
+    public void configureResources(Map<String, ResourcePlugin> resources) {
+        resources.put("dummy-oauth", ResourceBuilder.build("dummy-oauth", DummyOauth2Resource.class));
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put(
+            "copy-attribute-to-response",
+            PolicyBuilder.build("copy-attribute-to-response", CopyAttributeToResponsePayloadPolicy.class)
+        );
+    }
+
+    @ParameterizedTest
+    @DeployApi("/apis/user-info-without-resource.json")
+    @ValueSource(strings = { PAYLOAD_EXTRACTION_PATH, NO_PAYLOAD_EXTRACTION_PATH })
+    @DisplayName("Should not be authorized because of no auth server found for configuration")
+    void shouldNotBeAuthorizedWithoutResource(String flowPath, WebClient webClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("I'm the backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = webClient.get("/test-no-resource" + flowPath).rxSend().test();
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.bodyAsString()).isEqualTo("No OpenID Connect authorization server has been configured");
+
+                return true;
+            });
+
+        wiremock.verify(exactly(0), getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @ParameterizedTest(name = "Header: ''{1}''")
+    @MethodSource("provideEmptyOrNotBearerAuthorizationHeaders")
+    @DisplayName("Should not be authorized because of bad Authorization header")
+    void shouldNotBeAuthorizedWithWrongHeader(HttpHeaders headers, String testName, WebClient webClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("I'm the backend")));
+
+        final HttpRequest<Buffer> request = webClient.get("/test" + PAYLOAD_EXTRACTION_PATH);
+
+        headers.forEach(h -> request.putHeader(h.getKey(), h.getValue()));
+
+        final TestObserver<HttpResponse<Buffer>> obs = request.rxSend().test();
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.bodyAsString()).isEqualTo("No OAuth authorization header was supplied");
+                assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo("Bearer realm=gravitee.io - No OAuth authorization header was supplied");
+                return true;
+            });
+
+        wiremock.verify(exactly(0), getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should not be authorized because of bad empty Bearer access token")
+    void shouldNotBeAuthorizedWithEmptyBearerToken(WebClient webClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("I'm the backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = webClient
+            .get("/test" + PAYLOAD_EXTRACTION_PATH)
+            .putHeader(HttpHeaderNames.AUTHORIZATION, "Bearer")
+            .rxSend()
+            .test();
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.bodyAsString()).isEqualTo("No OAuth access token was supplied");
+                assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo("Bearer realm=gravitee.io - No OAuth access token was supplied");
+                return true;
+            });
+
+        wiremock.verify(exactly(0), getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should not be authorized when token is invalid in the resource")
+    void shouldBeAuthorized(WebClient webClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("I'm the backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = webClient
+            .get("/test" + NO_PAYLOAD_EXTRACTION_PATH)
+            .putHeader(HttpHeaderNames.AUTHORIZATION, "Bearer invalid_token")
+            .rxSend()
+            .test();
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo("Bearer realm=gravitee.io - Invalid OAuth access token was supplied");
+                assertThat(response.bodyAsString()).contains(DummyOauth2Resource.EXTRACTED_FAIL_PAYLOAD);
+                return true;
+            });
+
+        wiremock.verify(exactly(0), getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should receive 503 - Service Unavailable when resource throws")
+    void shouldReturn503(WebClient webClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("I'm the backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = webClient
+            .get("/test" + NO_PAYLOAD_EXTRACTION_PATH)
+            .putHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + CAUSING_ERROR_TOKEN)
+            .rxSend()
+            .test();
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(503);
+                assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo(
+                        "Bearer realm=gravitee.io - Error occurs during OAuth access token validation: " +
+                        DummyOauth2Resource.THROWABLE_MESSAGE
+                    );
+                assertThat(response.bodyAsString()).contains("Service Unavailable");
+                return true;
+            });
+
+        wiremock.verify(exactly(0), getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { PAYLOAD_EXTRACTION_PATH, NO_PAYLOAD_EXTRACTION_PATH })
+    @DisplayName("Should be authorized and get user info if configured")
+    void shouldBeAuthorized(String flowPath, WebClient webClient) {
+        wiremock.stubFor(get("/endpoint" + flowPath).willReturn(ok("I'm the backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = webClient
+            .get("/test" + flowPath)
+            .putHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + flowPath)
+            .rxSend()
+            .test();
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                if (PAYLOAD_EXTRACTION_PATH.equals(flowPath)) {
+                    assertThat(response.bodyAsString()).contains(DummyOauth2Resource.EXTRACTED_PAYLOAD);
+                } else if (NO_PAYLOAD_EXTRACTION_PATH.equals(flowPath)) {
+                    assertThat(response.bodyAsString()).contains(CopyAttributeToResponsePayloadPolicy.NO_CONTENT);
+                }
+                return true;
+            });
+
+        wiremock.verify(exactly(1), getRequestedFor(urlPathEqualTo("/endpoint" + flowPath)));
+    }
+
+    private static Stream<Arguments> provideEmptyOrNotBearerAuthorizationHeaders() {
+        return Stream.of(
+            Arguments.of(HttpHeaders.create(), "No Authorization header"),
+            Arguments.of(HttpHeaders.create().add(HttpHeaderNames.AUTHORIZATION, (CharSequence) null), "null"),
+            Arguments.of(HttpHeaders.create().add(HttpHeaderNames.AUTHORIZATION, ""), ""),
+            Arguments.of(HttpHeaders.create().add(HttpHeaderNames.AUTHORIZATION, "Basic"), "Basic")
+        );
+    }
+}

--- a/src/test/resources/apis/user-info-without-resource.json
+++ b/src/test/resources/apis/user-info-without-resource.json
@@ -1,0 +1,69 @@
+{
+  "id": "my-api-no-resource",
+  "name": "my-api-no-resource",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test-no-resource",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "No payload extraction flow",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/no-payload-extraction",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "OpenId Connect - UserInfo",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-openid-userinfo",
+          "configuration": {
+            "oauthResource": "dummy-oauth-resource",
+            "extractPayload": false
+          }
+        }
+      ],
+      "post": []
+    },
+    {
+      "name": "Payload extraction flow",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/payload-extraction",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "OpenId Connect - UserInfo",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-openid-userinfo",
+          "configuration": {
+            "oauthResource": "dummy-oauth-resource",
+            "extractPayload": true
+          }
+        }
+      ],
+      "post": [
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/user-info.json
+++ b/src/test/resources/apis/user-info.json
@@ -1,0 +1,96 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "No payload extraction flow",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/no-payload-extraction",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "OpenId Connect - UserInfo",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-openid-userinfo",
+          "configuration": {
+            "oauthResource": "dummy-oauth-resource",
+            "extractPayload": false
+          }
+        }
+      ],
+      "post": []
+    },
+    {
+      "name": "Payload extraction flow",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/payload-extraction",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "OpenId Connect - UserInfo",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-openid-userinfo",
+          "configuration": {
+            "oauthResource": "dummy-oauth-resource",
+            "extractPayload": true
+          }
+        }
+      ],
+      "post": []
+    },
+    {
+      "name": "Attribute copy to response payload",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "post": [{
+        "name": "Copy attribute from UserInfoPolicy to payload",
+        "description": "",
+        "enabled": true,
+        "policy": "copy-attribute-to-response",
+        "configuration": {
+        }
+      }]
+    }
+  ],
+  "resources": [
+    {
+      "name": "dummy-oauth-resource",
+      "enabled": true,
+      "type": "dummy-oauth",
+      "configuration": {
+      }
+    }
+  ]
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6883
https://github.com/gravitee-io/issues/issues/7915

**Description**

Putting UserInfoResponse into header was causing error due to `\t` and `\n` and the error was not caught properly.
We replace it with a simpler message

Take the opportunity to test the policy.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-issues-6883-openid-fail-header-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-openid-connect-userinfo/1.5.1-issues-6883-openid-fail-header-SNAPSHOT/gravitee-policy-openid-connect-userinfo-1.5.1-issues-6883-openid-fail-header-SNAPSHOT.zip)
  <!-- Version placeholder end -->
