### PR TITLE
chore: bump gravitee-parent to 20.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>20.3</version>
     </parent>
 
     <properties>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-bump-parent-20-3-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-openid-connect-userinfo/1.5.1-bump-parent-20-3-SNAPSHOT/gravitee-policy-openid-connect-userinfo-1.5.1-bump-parent-20-3-SNAPSHOT.zip)
  <!-- Version placeholder end -->
