### PR TITLE
fix: add documentation of UserInfo policy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,3 +20,17 @@ endif::[]
 |===
 
 == Description
+
+Use the `policy-openid-userinfo` to get the OpenId Connect user info from an OAuth2 resource through its UserInfo endpoint.
+
+NOTE: The request will fail with a 401 status if the policy's Oauth2 resource is misconfigured or not defined at all. To troubleshoot this, check the `WWW_Authenticate` header for more information.
+
+== Configuration
+
+Use the following options to configure the policy:
+
+|===
+|Property |Required |Description |Type |Default
+
+|oauthResource|X|The OAuth2 resource used to get UserInfo|string|
+|extractPayload||When set to  `true`, the payload of the response from the `UserInfo` endpoint is set in the `openid.userinfo.payload` gateway attribute|boolean|


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.2-add-documentation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-openid-connect-userinfo/1.5.2-add-documentation-SNAPSHOT/gravitee-policy-openid-connect-userinfo-1.5.2-add-documentation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
