### PR TITLE
Apim 2140 OIDC

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,22 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.openid.userinfo.UserInfoPolicy
 type=policy
 category=security
 icon=openid-connect.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,7 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:openid:userinfo:configuration:UserInfoPolicyConfiguration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
   "properties" : {
     "oauthResource" : {
       "title": "OpenID Connect resource",


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

- update renovate
- update schema form & add exec phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-apim-2140-oidc-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-openid-connect-userinfo/1.6.0-apim-2140-oidc-SNAPSHOT/gravitee-policy-openid-connect-userinfo-1.6.0-apim-2140-oidc-SNAPSHOT.zip)
  <!-- Version placeholder end -->
