### PR TITLE
Enable policy on REQUEST phase for message APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.29</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-expression-language.version>1.9.3</gravitee-expression-language.version>
     </properties>
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -7,3 +7,4 @@ type=policy
 category=security
 icon=openid-connect.svg
 proxy=REQUEST
+message=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3594
gravitee-io/issues#9430

**Description**

Enable policy on REQUEST phase for message APIs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-gaetanmaisse-patch-1-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-openid-connect-userinfo/1.7.0-gaetanmaisse-patch-1-SNAPSHOT/gravitee-policy-openid-connect-userinfo-1.7.0-gaetanmaisse-patch-1-SNAPSHOT.zip)
  <!-- Version placeholder end -->
